### PR TITLE
Add some help text

### DIFF
--- a/help_text/bf54a56c9f297afaee1678fa51d9c1ee.md
+++ b/help_text/bf54a56c9f297afaee1678fa51d9c1ee.md
@@ -1,0 +1,21 @@
+This error means that a value of the ID attribute already exists on the page.  The HTML specification states that the value of an ID must be unique.
+
+If you need to use the same ID twice, it is recommenced to use it as a class instead.
+
+The following example is **not valid**:
+```
+<div id='test'>content</div>
+<div id='test'>more content</div>
+```
+
+The following example **is valid**:
+```
+<div id='test'>content</div>
+<div id='another_test'>more content</div>
+```
+
+The following example **is valid**:
+```
+<div class='test'>content</div>
+<div class='test'>more content</div>
+```

--- a/src/Metric.php
+++ b/src/Metric.php
@@ -78,17 +78,58 @@ class Metric extends MetricInterface
         }
 
         foreach ($result->errors as $error) {
-            $machine_name = md5($error->message);
-            $mark = $this->getMark($machine_name, $error->message, 1, '', $this->getHelpText($machine_name));
+            $name = $this->getMarkNameFromMessage($error->message);
+
+            $machine_name = md5($name);
+            
+            $mark = $this->getMark($machine_name, $name, 1, '', $this->getHelpText($machine_name));
+            
+            $value_found = null;
+            if ($name != $error->message) {
+                $value_found = $error->message;
+            }
 
             $page->addMark($mark, array(
-                'line'    => $error->line,
-                'col'     => $error->col,
-                'context' => $error->source,
+                'line'        => $error->line,
+                'col'         => $error->col,
+                'context'     => $error->source, 
+                'value_found' => $value_found,
             ));
         }
 
         return true;
+    }
+
+    /**
+     * Get the machine name for a given error message
+     * 
+     * @param $error_message
+     * @return string
+     */
+    public function getMarkNameFromMessage($error_message)
+    {
+        switch ($error_message) {
+            case (preg_match('/attribute (.*) not allowed on element (.*) at this point./i', $error_message) ? true : false) :
+                $name = 'Attribute _ is not allowed on _ element';
+                break;
+            case (preg_match('/Bad value (.*) for attribute (.*) on element (.*): Illegal character in query: not a URL code point./i', $error_message) ? true : false) :
+                $name = 'Bad value _ for attribute _ on element _: Illegal character in query';
+                break;
+            case (preg_match('/Duplicate ID (.*)./i', $error_message) ? true : false) :
+                $name = 'Duplicate ID _';
+                break;
+            case (preg_match('/(.*) is not a member of a group specified for any attribute/i', $error_message) ? true : false) :
+                $name = '_ is not a member of a group specified for any attribute';
+                break;
+            case (preg_match('/Bad value (.*) for attribute (.*) on element (.*): Expected a digit but saw (.*) instead./i', $error_message) ? true : false) :
+                $name = 'Bad value _ for attribute _ on element _: Expected a digit but saw _ instead';
+                break;
+            default:
+                $name = $error_message;
+                break;
+        }
+
+        return $name;
     }
 
     /**

--- a/src/Metric.php
+++ b/src/Metric.php
@@ -108,20 +108,20 @@ class Metric extends MetricInterface
      */
     public function getMarkNameFromMessage($error_message)
     {
-        switch ($error_message) {
-            case (preg_match('/attribute (.*) not allowed on element (.*) at this point./i', $error_message) ? true : false) :
+        switch (true) {
+            case (preg_match('/attribute (.*) not allowed on element (.*) at this point./i', $error_message)) :
                 $name = 'Attribute _ is not allowed on _ element';
                 break;
-            case (preg_match('/Bad value (.*) for attribute (.*) on element (.*): Illegal character in query: not a URL code point./i', $error_message) ? true : false) :
+            case (preg_match('/Bad value (.*) for attribute (.*) on element (.*): Illegal character in query: not a URL code point./i', $error_message)) :
                 $name = 'Bad value _ for attribute _ on element _: Illegal character in query';
                 break;
-            case (preg_match('/Duplicate ID (.*)./i', $error_message) ? true : false) :
+            case (preg_match('/Duplicate ID (.*)./i', $error_message)) :
                 $name = 'Duplicate ID _';
                 break;
-            case (preg_match('/(.*) is not a member of a group specified for any attribute/i', $error_message) ? true : false) :
+            case (preg_match('/(.*) is not a member of a group specified for any attribute/i', $error_message)) :
                 $name = '_ is not a member of a group specified for any attribute';
                 break;
-            case (preg_match('/Bad value (.*) for attribute (.*) on element (.*): Expected a digit but saw (.*) instead./i', $error_message) ? true : false) :
+            case (preg_match('/Bad value (.*) for attribute (.*) on element (.*): Expected a digit but saw (.*) instead./i', $error_message)) :
                 $name = 'Bad value _ for attribute _ on element _: Expected a digit but saw _ instead';
                 break;
             default:

--- a/tests/MetricTest.php
+++ b/tests/MetricTest.php
@@ -1,0 +1,38 @@
+<?php
+namespace SiteMaster\Plugins\Metric_w3c_html;
+
+class MetricTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function getMarkNameFromMessage()
+    {
+        $metric = new Metric('metric_w3c_html');
+        
+        $this->assertEquals(
+            'Attribute _ is not allowed on _ element',
+            $metric->getMarkNameFromMessage('Attribute &" not allowed on element iframe at this point.')
+        );
+        
+        $this->assertEquals(
+            'Bad value _ for attribute _ on element _: Illegal character in query',
+            $metric->getMarkNameFromMessage('Bad value mailto:?body=Check%20out%20this%20page%20http://otoe.unl.edu/educational-areas&subject=Water & Environment; UNL Extension in Otoe County for attribute href on element a: Illegal character in query: not a URL code point.')
+        );
+        
+        $this->assertEquals(
+            'Duplicate ID _',
+            $metric->getMarkNameFromMessage('Duplicate ID s-lg-col-2.')
+        );
+
+        $this->assertEquals(
+            '_ is not a member of a group specified for any attribute',
+            $metric->getMarkNameFromMessage('"SOFT" is not a member of a group specified for any attribute')
+        );
+
+        $this->assertEquals(
+            'Bad value _ for attribute _ on element _: Expected a digit but saw _ instead',
+            $metric->getMarkNameFromMessage('Bad value 130px for attribute width on element img: Expected a digit but saw p instead.')
+        );
+    }
+}


### PR DESCRIPTION
This also fixes an issue where the validator was not returning any data that would allow us to easily group similar messages.  Message names sometimes include values of attributes and elements found in the code, which in turn would mean that we would have to create help text for each value.  That is unreasonable, so this PR also includes a fix to parse and group similar message text.