### PR TITLE
validate error pages by default

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -229,16 +229,16 @@
         },
         {
             "name": "rexxars/html-validator",
-            "version": "2.0.0",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rexxars/html-validator.git",
-                "reference": "9a6d8874890945c66bf047bb8828b01402547add"
+                "reference": "0efbde751442773c820e2525fb9fcd05a0618a23"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rexxars/html-validator/zipball/9a6d8874890945c66bf047bb8828b01402547add",
-                "reference": "9a6d8874890945c66bf047bb8828b01402547add",
+                "url": "https://api.github.com/repos/rexxars/html-validator/zipball/0efbde751442773c820e2525fb9fcd05a0618a23",
+                "reference": "0efbde751442773c820e2525fb9fcd05a0618a23",
                 "shasum": ""
             },
             "require": {
@@ -266,7 +266,7 @@
                 }
             ],
             "description": "Validates HTML using Validator.nu",
-            "time": "2016-08-07T13:13:35+00:00"
+            "time": "2017-02-21T23:30:36+00:00"
         }
     ],
     "packages-dev": [],

--- a/src/Metric.php
+++ b/src/Metric.php
@@ -229,14 +229,14 @@ class Metric extends MetricInterface
      * Get the results for a given uri
      *
      * @param $uri
-     * @return \HtmlValidator\Response
+     * @return \HtmlValidator\HtmlValidator\Response|\HtmlValidator\Response
      */
     public function getResults($uri)
     {
         $validator = new Validator($this->options['service_url']);
         
         try {
-            return $validator->validateUrl($uri);
+            return $validator->validateUrl($uri, ['checkErrorPages'=>true]);
         } catch (\Exception $e) {
             return null;
         }

--- a/www/templates/html/Metric.tpl.php
+++ b/www/templates/html/Metric.tpl.php
@@ -7,6 +7,7 @@
     if (isset($parent) && $parent->context->getRawObject() instanceof \SiteMaster\Core\Auditor\Site\Page\MetricGrade) {
         $page = $parent->context->getPage();
         $url .= '?doc=' . urlencode($page->uri);
+        $url .= '&checkerrorpages=yes';
     }
     ?>
     To find and fix these errors, you can run your page though the <a href="<?php echo $url ?>">W3C HTML validator</a>.


### PR DESCRIPTION
The nu validator recently added an option to enable validating 'error' pages, or pages that do not return a 200 status. This PR implements that option and turns it on by default. Error pages should also be valid, and instead were causing pages to always fail the validation metric.