### PR TITLE
Ignore chunk error

### DIFF
--- a/src/Metric.php
+++ b/src/Metric.php
@@ -89,7 +89,7 @@ class Metric extends MetricInterface
         
         foreach ($result->getErrors() as $error) {
             // skip allowed errors
-            if (allowError($error->getText())) {
+            if ($this->allowError($error->getText())) {
                 contiune;
             }
 

--- a/src/Metric.php
+++ b/src/Metric.php
@@ -90,7 +90,7 @@ class Metric extends MetricInterface
         foreach ($result->getErrors() as $error) {
             // skip allowed errors
             if ($this->allowError($error->getText())) {
-                contiune;
+                continue;
             }
 
             /**

--- a/src/Metric.php
+++ b/src/Metric.php
@@ -88,6 +88,11 @@ class Metric extends MetricInterface
         }
         
         foreach ($result->getErrors() as $error) {
+            // skip allowed errors
+            if (allowError($error->getText())) {
+                contiune;
+            }
+
             /**
              * @var $error \HtmlValidator\Message
              */
@@ -111,6 +116,15 @@ class Metric extends MetricInterface
         }
 
         return true;
+    }
+
+    public function allowError($errorMessage) {
+        // allow chunk error since not really an issue
+        if (strpos(strtolower($errorMessage), 'premature end of chunk coded message body: closing chunk expected') !== false) {
+            return true;
+        }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
Ignores validator error `Premature end of chunk coded message body: closing chunk expected`
until https://github.com/validator/validator/issues/865 is available and deployed at validator.unl.edu (https://git.unl.edu/dxg/internal-documentation/-/wikis/validator.unl.edu)