### PR TITLE
Add exception for text wrap error

### DIFF
--- a/src/Metric.php
+++ b/src/Metric.php
@@ -136,6 +136,9 @@ class Metric extends MetricInterface
         if (strpos(strtolower($errorMessage), "css: “ascent-override”: property “ascent-override” doesn't exist.") !== false) {
             return true;
         }
+        if (strpos(strtolower($errorMessage), "css: “text-wrap”: property “text-wrap” doesn't exist.") !== false) {
+            return true;
+        }
 
         return false;
     }


### PR DESCRIPTION
There is an error for text-wrap property does not exist but it does

[Reference](https://developer.mozilla.org/en-US/docs/Web/CSS/text-wrap)